### PR TITLE
Fix headless progress updates

### DIFF
--- a/freeeed-processing/src/main/java/org/freeeed/services/Stats.java
+++ b/freeeed-processing/src/main/java/org/freeeed/services/Stats.java
@@ -273,7 +273,9 @@ public class Stats {
     }
     private void updateProgressReport() {
         ProcessProgressUI ui = ProcessProgressUI.getInstance();
-        ui.updateProgress(itemCount);
+        if (ui != null) {
+            ui.updateProgress(itemCount);
+        }
     }
 
 }

--- a/freeeed-processing/src/test/java/org/freeeed/services/StatsTest.java
+++ b/freeeed-processing/src/test/java/org/freeeed/services/StatsTest.java
@@ -1,0 +1,16 @@
+package org.freeeed.services;
+
+import org.freeeed.ui.ProcessProgressUI;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+public class StatsTest {
+
+    @Test
+    public void increaseItemCountWorksWithoutProgressUi() {
+        assertNull(ProcessProgressUI.getInstance());
+
+        Stats.getInstance().increaseItemCount();
+    }
+}


### PR DESCRIPTION
## Summary
- Guard progress UI updates when no Swing progress dialog exists
- Add a regression test for headless Stats.increaseItemCount()

## Testing
- env JAVA_HOME=/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@11/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin mvn -pl freeeed-processing -Dtest=org.freeeed.services.StatsTest test
- env JAVA_HOME=/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@11/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin mvn -pl freeeed-processing -DskipTests package