### PR TITLE
docs: add mission statement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # FreeEed
 
+> **Mission:** Make professional-grade eDiscovery and AI over sensitive documents *affordable, private, and self-hosted* — open-source software so any lawyer, investigator, or small firm can process, search, review, and question their own data on their own machine, without sending it to anyone.
+
 ## Quickest Start
 - [Buy support](https://freeeed.org/support/) and [request](https://freeeed.org) a ready-to-run VM
 - [Download the latest release](https://shmsoft.s3.amazonaws.com/releases/freeeed_complete_pack-10.8.1.zip)


### PR DESCRIPTION
Adds a one-line **Mission** statement directly under the `# FreeEed` title, so it's the first thing visitors and watchers see on the repo homepage.

> **Mission:** Make professional-grade eDiscovery and AI over sensitive documents *affordable, private, and self-hosted* — open-source software so any lawyer, investigator, or small firm can process, search, review, and question their own data on their own machine, without sending it to anyone.

It articulates FreeEed's differentiators surfaced repeatedly in user conversations: affordable, private/on-prem, self-hosted, open-source, AI over your own data.

Targeting `main` directly (not `dev`) because GitHub renders the homepage README only from the default branch — the mission needs to be on `main` to be visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)