### PR TITLE
chore: sync main → dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 ## Quickest Start
 - [Buy support](https://freeeed.org/support/) and [request](https://freeeed.org) a ready-to-run VM
 - [Download the latest release](https://shmsoft.s3.amazonaws.com/releases/freeeed_complete_pack-10.8.1.zip)
-- [Daily build](https://shmsoft.s3.amazonaws.com/releases/freeeed_complete_pack-10.8.2-SNAPSHOT.zip) *(unstable)*
-- [Daily build of Windows Installer](https://shmsoft.s3.us-east-1.amazonaws.com/releases/FreeEed-10.8.2-SNAPSHOT-Windows.exe) *(unstable)*
-- [Daily build of Linux Installer](https://shmsoft.s3.us-east-1.amazonaws.com/releases/FreeEed-10.8.2-SNAPSHOT-Linux.run) *(unstable)*
+- [Daily build](https://shmsoft.s3.amazonaws.com/releases/freeeed_complete_pack-latest.zip) *(unstable)*
+- [Daily build of Windows Installer](https://shmsoft.s3.us-east-1.amazonaws.com/releases/FreeEed-latest-Windows.exe) *(unstable)*
+- [Daily build of Linux Installer](https://shmsoft.s3.us-east-1.amazonaws.com/releases/FreeEed-latest-Linux.run) *(unstable)*
 
 ## Quick Start
 1. Follow the [installation instructions](https://github.com/shmsoft/FreeEed/wiki/FreeEed-Installation)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # FreeEed
 
+> **Mission:** Make professional-grade eDiscovery and AI over sensitive documents *affordable, private, and self-hosted* — open-source software so any lawyer, investigator, or small firm can process, search, review, and question their own data on their own machine, without sending it to anyone.
+
 ## Quickest Start
 - [Buy support](https://freeeed.org/support/) and [request](https://freeeed.org) a ready-to-run VM
 - [Download the latest release](https://shmsoft.s3.amazonaws.com/releases/freeeed_complete_pack-10.8.1.zip)


### PR DESCRIPTION
Keeps `dev` current with `main` so the branches don't drift.

`main` is currently ahead of `dev` by:
- **Daily-build links fix** — point S3 URLs at the stable `latest` build (already on `main`, missing from `dev`).
- **Mission statement in README** (once #563 merges to `main`, it flows in here automatically).

Routine housekeeping per the repo's `feature → dev → main` workflow — this back-merge keeps `dev` from conflicting on the next forward merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)