### PR TITLE
Fix stale 'unzip key' onboarding step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Quick Start
 1. Follow the [installation instructions](https://github.com/shmsoft/FreeEed/wiki/FreeEed-Installation)
-2. Request an unzip key by writing to [mark@scaia.ai](mailto:mark@scaia.ai). Tell us a little about yourself — we’d love to hear from you.
+2. Run FreeEed and register on first launch — we’ll email you a free activation key right away. Tell us a little about yourself; we’d love to hear from you. ([mark@scaia.ai](mailto:mark@scaia.ai))
 
 ## Capabilities
 - Works on Windows, macOS, Linux, VirtualBox, and Amazon AWS cloud


### PR DESCRIPTION
The README Quick Start still told users to **request an unzip key** — the retired ZIP-password flow. The download page was fixed in June, but the README (which the download page links to for install instructions) was missed, so prospects reading 'how to install' were still told to ask for an unzip key.

Two recent inbound leads (Ansh Aggarwal / Chiacchio IP, and earlier Henderson Phillips-Wilborn) asked for an unzip key as a result.

This updates step 2 to the current flow: **run FreeEed and register on first launch → we email a free activation key**. Wiki install page was checked and is already clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)