### PR TITLE
Sync main → dev: README unzip-key fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Quick Start
 1. Follow the [installation instructions](https://github.com/shmsoft/FreeEed/wiki/FreeEed-Installation)
-2. Request an unzip key by writing to [mark@scaia.ai](mailto:mark@scaia.ai). Tell us a little about yourself — we’d love to hear from you.
+2. Run FreeEed and register on first launch — we’ll email you a free activation key right away. Tell us a little about yourself; we’d love to hear from you. ([mark@scaia.ai](mailto:mark@scaia.ai))
 
 ## Capabilities
 - Works on Windows, macOS, Linux, VirtualBox, and Amazon AWS cloud


### PR DESCRIPTION
Brings the README onboarding fix (#565) into dev so the stale 'unzip key' step isn't reintroduced on the next dev→main promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)